### PR TITLE
Feat/cicd oss housekeeping

### DIFF
--- a/python/racfu/racfu.py
+++ b/python/racfu/racfu.py
@@ -13,7 +13,7 @@ class SecurityResult:
             request: dict,
             raw_request: bytes | None,
             raw_result: bytes | None,
-            result: dict[str, Any] | None
+            result: dict[str, Any] | None,
     ):
         self.request = request
         self.raw_request = raw_request

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def generate_json_schema_header() -> None:
                     "",
                     "#endif",
                 ],
-            )
+            ),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def generate_json_schema_header() -> None:
                     f'#define RACFU_SCHEMA R"({schema})"_json',
                     "",
                     "#endif",
-                ]
+                ],
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def main():
                 ),
                 extra_link_args=["-m64", "-Wl,-b,edit=no"],
                 extra_objects=[f"{assembled_object_path}"],
-            )
+            ),
         ],
         "cmdclass": {"build_ext": build_with_asm_ext},
     }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def assemble(asm_file: str, asm_directory: Path) -> None:
 def generate_json_schema_header() -> None:
     """Generate RACFu JSON schema header."""
     schema_absolute_path = Path.cwd() / "schema.json"
-    with open(schema_absolute_path, "r") as f:
+    with open(schema_absolute_path) as f:
         schema = json.dumps(json.load(f), separators=(",", ":"))
     schema_header_absolute_path = Path.cwd() / "racfu" / "racfu_schema.hpp"
     with open(schema_header_absolute_path, "w") as f:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def generate_json_schema_header() -> None:
         )
 
 
-class build_with_asm_ext(build_ext):
+class BuildWithASMExt(build_ext):
     """Build Python extension that includes assembler code."""
     def run(self):
         os.environ["CC"] = "ibm-clang64"
@@ -91,7 +91,7 @@ def main():
                 extra_objects=[f"{assembled_object_path}"],
             ),
         ],
-        "cmdclass": {"build_ext": build_with_asm_ext},
+        "cmdclass": {"build_ext": BuildWithASMExt},
     }
     setup(**setup_args)
 


### PR DESCRIPTION
There were a bunch of things in setup.py that didn't adhere to PEP8 and other minor Python best practices. This has been resolved. Nothing major has been changed so everything should still work correctly.